### PR TITLE
release 0.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -738,14 +738,13 @@ checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 
 [[package]]
 name = "tsuki-scheduler"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "async-std",
  "chrono",
  "cron",
  "tokio",
  "uuid",
- "wasm-bindgen",
  "wasm-bindgen-futures",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tsuki-scheduler"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 authors = ["4t145<u4t145@163.com>"]
 description = "A simple, light wight, composable and extensible scheduler for every runtime."
@@ -17,8 +17,7 @@ chrono = { version = "0.4" }
 cron = { version = "0", optional = true }
 async-std = { version = "1", optional = true }
 tokio = { version = "1", optional = true }
-wasm-bindgen-futures = { version = "0.4.42", optional = true }
-wasm-bindgen = { version = "0.2.92", optional = true }
+wasm-bindgen-futures = { version = "0.4", optional = true }
 uuid = { version = "1.8", optional = true }
 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,9 @@ license = "Apache-2.0"
 keywords = ["cron", "scheduler", "task", "wasm", "time"]
 readme = "README.md"
 
+[package.metadata.docs.rs]
+all-features = true
+
 [dependencies]
 chrono = { version = "0.4" }
 cron = { version = "0", optional = true }
@@ -17,6 +20,7 @@ tokio = { version = "1", optional = true }
 wasm-bindgen-futures = { version = "0.4.42", optional = true }
 wasm-bindgen = { version = "0.2.92", optional = true }
 uuid = { version = "1.8", optional = true }
+
 
 [features]
 async-scheduler = ["tokio?/time"]

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Tsuki-Scheduler
 [![Crates.io Version](https://img.shields.io/crates/v/tsuki-scheduler)](https://crates.io/crates/tsuki-scheduler)
 ![Release status](https://github.com/4t145/tsuki-scheduler/actions/workflows/test-and-release.yml/badge.svg)
-![docs.rs](https://img.shields.io/docsrs/tsuki-scheduler)
+[![docs.rs](https://img.shields.io/docsrs/tsuki-scheduler)](https://docs.rs/tsuki-scheduler)
 
 A simple, light wight, composable and extensible scheduler for every runtime.
-```
+```text
 Scheduler = Schedule × Runtime
 ```
 
@@ -47,8 +47,36 @@ let mut scheduler = Scheduler::new(Promise);
 let mut scheduler = Scheduler::new(Thread);
 
 // or you may use the async wrapper
-let mut scheduler_runner = AsyncSchedulerRunner::new(Tokio);
+let mut scheduler_runner = AsyncSchedulerRunner::<Tokio>::default();
 let client = scheduler_runner.client();
+```
+
+### Compose schedules
+What if I want to create a very complex schedule like this:
+
+1. Firstly it will run at 10 seconds later.
+2. And then, it will run at every hour's 10th minute.
+3. Meanwhile, it will run every 80 minutes.
+4. Though, it won't run within 30 minutes after the last run.
+5. Finally, it will stop running after 100 days later.
+
+And you can actually do it:
+```rust
+use tsuki_scheduler::prelude::*;
+use chrono::TimeDelta;
+
+let start_time = now() + TimeDelta::seconds(10);
+let schedule = Once::new(start_time)
+    .then(
+        Cron::utc_from_cron_expr("00 10 * * * *")
+            .expect("invalid cron")
+            .or(Period::new(
+                TimeDelta::minutes(80),
+                start_time + TimeDelta::minutes(80),
+            ))
+            .throttling(TimeDelta::minutes(30)),
+    )
+    .before(start_time + TimeDelta::days(100));
 ```
 
 ### Add executes and delete tasks

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ In a async runtime, you may spawn a task for scheduler to execute periodically d
 |tokio|enable tokio runtime |
 |async_std|enable async_std runtime |
 |thread|enable thread runtime |
-|wasm|enable wasm runtime |
+|promise|enable js promise runtime |
 |async-scheduler|a default async wrapper for async runtime|
 
 

--- a/examples/tokio.rs
+++ b/examples/tokio.rs
@@ -9,7 +9,7 @@ pub enum Event {
 
 #[tokio::main]
 async fn main() {
-    let async_runner = AsyncSchedulerRunner::<Tokio, Vec<_>>::default();
+    let async_runner = AsyncSchedulerRunner::tokio();
     let async_client = async_runner.client();
     let shutdown_signal = Box::pin(tokio::time::sleep(std::time::Duration::from_secs(10)));
     let running_handle = tokio::spawn(async_runner.run_with_shutdown_signal(shutdown_signal));
@@ -42,8 +42,5 @@ async fn main() {
     tokio::time::sleep(std::time::Duration::from_secs(5)).await;
     async_client.remove_task(tokio_task_id);
     tokio::time::sleep(std::time::Duration::from_secs(5)).await;
-    let runner = running_handle.await.unwrap();
-    for task in runner.scheduler.handle_manager {
-        task.await.unwrap();
-    }
+    let _runner = running_handle.await.unwrap();
 }

--- a/src/async_scheduler/async_std.rs
+++ b/src/async_scheduler/async_std.rs
@@ -1,5 +1,4 @@
-
-use crate::runtime::AsyncStd;
+use crate::{runtime::AsyncStd, AsyncSchedulerRunner};
 
 use super::AsyncRuntime;
 
@@ -10,5 +9,11 @@ impl AsyncRuntime for AsyncStd {
             async_std::task::sleep(duration).await;
             waker.wake()
         });
+    }
+}
+
+impl AsyncSchedulerRunner<AsyncStd> {
+    pub fn async_std() -> Self {
+        Self::default()
     }
 }

--- a/src/async_scheduler/async_std.rs
+++ b/src/async_scheduler/async_std.rs
@@ -1,9 +1,14 @@
+
 use crate::runtime::AsyncStd;
 
 use super::AsyncRuntime;
 
 impl AsyncRuntime for AsyncStd {
-    fn sleep(&self, duration: std::time::Duration) -> impl async_std::prelude::Future<Output = ()> {
-        async_std::task::sleep(duration)
+    fn wake_after(&self, duration: std::time::Duration, ctx: &mut std::task::Context<'_>) {
+        let waker = ctx.waker().clone();
+        async_std::task::spawn(async move {
+            async_std::task::sleep(duration).await;
+            waker.wake()
+        });
     }
 }

--- a/src/async_scheduler/mod.rs
+++ b/src/async_scheduler/mod.rs
@@ -10,8 +10,8 @@ use crate::{handle_manager::HandleManager, runtime::Runtime, Scheduler, Task, Ta
 mod async_std;
 #[cfg(feature = "tokio")]
 mod tokio;
-
 pub trait AsyncRuntime: Runtime + Send + Sync {
+    /// wake runner after a duration
     fn wake_after(&self, duration: Duration, ctx: &mut std::task::Context<'_>);
 }
 
@@ -135,14 +135,6 @@ where
     runner: Option<AsyncSchedulerRunner<R, H>>,
     event_queue: VecDeque<Event<R>>,
     shutdown_signal: S,
-}
-
-unsafe impl<R, H, S> Send for AsyncSchedulerRunning<R, H, S>
-where
-    R: AsyncRuntime + Send,
-    H: HandleManager<R::Handle> + Send,
-    S: Future<Output = ()> + Send,
-{
 }
 
 impl<R, H, S> Unpin for AsyncSchedulerRunning<R, H, S>

--- a/src/async_scheduler/mod.rs
+++ b/src/async_scheduler/mod.rs
@@ -1,7 +1,8 @@
 use std::{
     collections::VecDeque,
-    future::Future,
+    future::{Future, Pending},
     sync::{Arc, Mutex},
+    time::Duration,
 };
 const DEFAULT_EXECUTE_DURATION: std::time::Duration = std::time::Duration::from_millis(100);
 use crate::{handle_manager::HandleManager, runtime::Runtime, Scheduler, Task, TaskUid};
@@ -10,15 +11,14 @@ mod async_std;
 #[cfg(feature = "tokio")]
 mod tokio;
 
-pub trait AsyncRuntime: Runtime {
-    fn sleep(&self, duration: std::time::Duration) -> impl Future<Output = ()>;
+pub trait AsyncRuntime: Runtime + Send + Sync {
+    fn wake_after(&self, duration: Duration, ctx: &mut std::task::Context<'_>);
 }
 
 #[derive(Debug)]
 enum Event<R: Runtime> {
     AddTask(TaskUid, Task<R>),
     RemoveTask(TaskUid),
-    Stop,
 }
 
 /// A implementation of async scheduler runner
@@ -77,32 +77,19 @@ impl<R: AsyncRuntime, H: HandleManager<R::Handle>> AsyncSchedulerRunner<R, H> {
         }
     }
     /// start running
-    pub async fn run(&mut self) {
-        let mut local_event_queue = VecDeque::new();
-        loop {
-            self.scheduler.runtime.sleep(self.execute_duration).await;
-            {
-                let mut add_task_queue = self.event_queue.lock().expect("lock event queue failed");
-                std::mem::swap(&mut local_event_queue, &mut add_task_queue);
-            }
-            while let Some(evt) = local_event_queue.pop_front() {
-                match evt {
-                    Event::AddTask(key, task) => {
-                        self.scheduler.add_task(key, task);
-                    }
-                    Event::RemoveTask(key) => {
-                        self.scheduler.delete_task(key);
-                    }
-                    Event::Stop => {
-                        // restore the event queue
-                        let mut add_task_queue =
-                            self.event_queue.lock().expect("lock event queue failed");
-                        add_task_queue.extend(local_event_queue);
-                        return;
-                    }
-                }
-            }
-            self.scheduler.execute_by_now();
+    pub fn run(self) -> AsyncSchedulerRunning<R, H, Pending<()>> {
+        self.run_with_shutdown_signal(std::future::pending())
+    }
+
+    /// start running with shutdown signal
+    pub fn run_with_shutdown_signal<S>(self, shutdown_signal: S) -> AsyncSchedulerRunning<R, H, S>
+    where
+        S: Future<Output = ()> + Send,
+    {
+        AsyncSchedulerRunning {
+            runner: Some(self),
+            event_queue: VecDeque::new(),
+            shutdown_signal,
         }
     }
 }
@@ -137,9 +124,83 @@ impl<R: AsyncRuntime> AsyncSchedulerClient<R> {
         let mut queue = self.event_queue.lock().expect("lock event queue failed");
         queue.push_back(Event::RemoveTask(key));
     }
-    /// stop the scheduler, if this method is called, the tasks in the queue will not be executed in next loop, and the scheduler will stop.
-    pub fn stop(&self) {
-        let mut queue = self.event_queue.lock().expect("lock event queue failed");
-        queue.push_back(Event::Stop);
+}
+
+pub struct AsyncSchedulerRunning<R, H, S>
+where
+    R: AsyncRuntime + Send,
+    H: HandleManager<R::Handle>,
+    S: Future<Output = ()> + Send,
+{
+    runner: Option<AsyncSchedulerRunner<R, H>>,
+    event_queue: VecDeque<Event<R>>,
+    shutdown_signal: S,
+}
+
+unsafe impl<R, H, S> Send for AsyncSchedulerRunning<R, H, S>
+where
+    R: AsyncRuntime + Send,
+    H: HandleManager<R::Handle> + Send,
+    S: Future<Output = ()> + Send,
+{
+}
+
+impl<R, H, S> Unpin for AsyncSchedulerRunning<R, H, S>
+where
+    R: AsyncRuntime,
+    H: HandleManager<R::Handle>,
+    S: Future<Output = ()> + Unpin + Send,
+{
+}
+impl<R, H, S> Future for AsyncSchedulerRunning<R, H, S>
+where
+    R: AsyncRuntime,
+    H: HandleManager<R::Handle>,
+    S: Future<Output = ()> + Unpin + Send,
+{
+    type Output = AsyncSchedulerRunner<R, H>;
+    fn poll(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Self::Output> {
+        let this = self.get_mut();
+        let shutdown_signal = std::pin::pin!(&mut this.shutdown_signal);
+        match shutdown_signal.poll(cx) {
+            std::task::Poll::Ready(_) => {
+                let runner = this.runner.take().expect("missing runner");
+                {
+                    let mut add_task_queue =
+                        runner.event_queue.lock().expect("lock event queue failed");
+                    while let Some(event) = this.event_queue.pop_back() {
+                        add_task_queue.push_front(event)
+                    }
+                }
+                std::task::Poll::Ready(runner)
+            }
+            std::task::Poll::Pending => {
+                let runner = this.runner.as_mut().expect("missing runner");
+                {
+                    let mut add_task_queue =
+                        runner.event_queue.lock().expect("lock event queue failed");
+                    std::mem::swap(&mut this.event_queue, &mut add_task_queue);
+                }
+                while let Some(evt) = this.event_queue.pop_front() {
+                    match evt {
+                        Event::AddTask(key, task) => {
+                            runner.scheduler.add_task(key, task);
+                        }
+                        Event::RemoveTask(key) => {
+                            runner.scheduler.delete_task(key);
+                        }
+                    }
+                }
+                runner.scheduler.execute_by_now();
+                runner
+                    .scheduler
+                    .runtime
+                    .wake_after(runner.execute_duration, cx);
+                std::task::Poll::Pending
+            }
+        }
     }
 }

--- a/src/async_scheduler/tokio.rs
+++ b/src/async_scheduler/tokio.rs
@@ -1,11 +1,17 @@
-use std::future::Future;
-
 use crate::runtime::Tokio;
 
 use super::AsyncRuntime;
 
 impl AsyncRuntime for Tokio {
-    fn sleep(&self, duration: std::time::Duration) -> impl Future<Output = ()> {
-        tokio::time::sleep(duration)
+    fn wake_after(
+        &self,
+        duration: std::time::Duration,
+        ctx: &mut std::task::Context<'_>,
+    ) {
+        let waker = ctx.waker().clone();
+        tokio::task::spawn(async move {
+            tokio::time::sleep(duration).await;
+            waker.wake()
+        });
     }
 }

--- a/src/async_scheduler/tokio.rs
+++ b/src/async_scheduler/tokio.rs
@@ -1,17 +1,19 @@
-use crate::runtime::Tokio;
+use crate::{runtime::Tokio, AsyncSchedulerRunner};
 
 use super::AsyncRuntime;
 
 impl AsyncRuntime for Tokio {
-    fn wake_after(
-        &self,
-        duration: std::time::Duration,
-        ctx: &mut std::task::Context<'_>,
-    ) {
+    fn wake_after(&self, duration: std::time::Duration, ctx: &mut std::task::Context<'_>) {
         let waker = ctx.waker().clone();
         tokio::task::spawn(async move {
             tokio::time::sleep(duration).await;
             waker.wake()
         });
+    }
+}
+
+impl AsyncSchedulerRunner<Tokio> {
+    pub fn tokio() -> Self {
+        Self::default()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![doc = include_str!("../README.md")]
 #[cfg(feature = "async-scheduler")]
 mod async_scheduler;
 #[cfg(feature = "async-scheduler")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![doc = include_str!("../README.md")]
+#![warn(clippy::unwrap_used, clippy::overflow_check_conditional)]
 #[cfg(feature = "async-scheduler")]
 mod async_scheduler;
 #[cfg(feature = "async-scheduler")]

--- a/src/schedule/mod.rs
+++ b/src/schedule/mod.rs
@@ -1,5 +1,3 @@
-use crate::Dtu;
-
 mod after;
 pub use after::*;
 mod or;
@@ -18,6 +16,8 @@ mod once;
 pub use once::*;
 mod period;
 pub use period::*;
+mod throttling;
+pub use throttling::*;
 
 pub trait Schedule {
     fn peek_next(&mut self) -> Option<Dtu>;
@@ -60,6 +60,9 @@ pub trait ScheduleExt: Schedule + Sized {
     }
     fn then<S: Schedule>(self, then: S) -> Then<Self, S> {
         then::Then::new(self, then)
+    }
+    fn throttling(self, interval: chrono::TimeDelta) -> Throttling<Self> {
+        Throttling::new(self, interval)
     }
 }
 

--- a/src/schedule/mod.rs
+++ b/src/schedule/mod.rs
@@ -25,6 +25,23 @@ pub trait Schedule {
     fn forward_to(&mut self, dtu: Dtu);
 }
 
+impl<T> Schedule for T
+where
+    T: AsMut<dyn Schedule>,
+{
+    fn peek_next(&mut self) -> Option<Dtu> {
+        self.as_mut().peek_next()
+    }
+
+    fn next(&mut self) -> Option<Dtu> {
+        self.as_mut().next()
+    }
+
+    fn forward_to(&mut self, dtu: Dtu) {
+        self.as_mut().forward_to(dtu)
+    }
+}
+
 pub fn forward_to_default<S: Schedule>(schedule: &mut S, dtu: Dtu) {
     while let Some(next) = schedule.peek_next() {
         if next > dtu {
@@ -63,6 +80,12 @@ pub trait ScheduleExt: Schedule + Sized {
     }
     fn throttling(self, interval: chrono::TimeDelta) -> Throttling<Self> {
         Throttling::new(self, interval)
+    }
+    fn dyn_box(self) -> Box<dyn Schedule>
+    where
+        Self: 'static,
+    {
+        Box::new(self)
     }
 }
 

--- a/src/schedule/period.rs
+++ b/src/schedule/period.rs
@@ -47,6 +47,9 @@ fn time_mod(x: TimeDelta, p: TimeDelta) -> TimeDelta {
     }
     let q_0 = s_x / (s_p + 1);
     let s_r = (s_x % (s_p + 1)) + ((n_p * q_0) / NANOS_PER_SEC);
+    if n_p == 0 {
+        return TimeDelta::new(s_r, n_x as u32).expect("invalid time delta");
+    }
     let n_r = n_x % n_p + ((NANOS_PER_SEC % n_p) * (s_r % n_p) % n_p);
     let x = TimeDelta::new(s_r, n_r as u32)
         .ok_or((s_r, n_r))

--- a/src/schedule/throttling.rs
+++ b/src/schedule/throttling.rs
@@ -1,0 +1,46 @@
+use chrono::TimeDelta;
+
+use crate::schedule::Schedule;
+pub use crate::Dtu;
+
+/// A schedule that throttles the inner schedule by a given interval.
+pub struct Throttling<S> {
+    pub inner: S,
+    pub last_call: Option<Dtu>,
+    pub interval: TimeDelta,
+}
+
+impl<S: Schedule> Throttling<S> {
+    pub fn new(inner: S, interval: TimeDelta) -> Self {
+        Self {
+            inner,
+            last_call: None,
+            interval,
+        }
+    }
+}
+
+impl<S: Schedule> Schedule for Throttling<S> {
+    fn peek_next(&mut self) -> Option<Dtu> {
+        let next = self.inner.peek_next()?;
+        if let Some(last_call) = self.last_call {
+            if next < last_call + self.interval {
+                return Some(last_call + self.interval);
+            }
+        }
+        Some(next)
+    }
+
+    fn next(&mut self) -> Option<Dtu> {
+        if let Some(last_call) = self.last_call {
+            self.forward_to(last_call + self.interval);
+        }
+        self.inner.next().inspect(|this_call| {
+            self.last_call = Some(*this_call);
+        })
+    }
+
+    fn forward_to(&mut self, dtu: Dtu) {
+        self.inner.forward_to(dtu);
+    }
+}

--- a/tests/test_schedules.rs
+++ b/tests/test_schedules.rs
@@ -109,3 +109,17 @@ pub fn test_once() {
     assert_eq!(schedule.next(), Some(day_0));
     assert_eq!(schedule.next(), None);
 }
+
+#[test]
+pub fn test_throttling() {
+    let day_0 = now();
+    let delta = TimeDelta::days(1);
+    let schedule = Period::new(delta, day_0);
+    let schedule = Throttling::new(schedule, TimeDelta::days(2));
+    let mut schedule = schedule.into_schedule();
+    assert_eq!(schedule.next(), Some(day_0));
+    assert_eq!(schedule.next(), Some(day_0 + delta * 2));
+    assert_eq!(schedule.next(), Some(day_0 + delta * 4));
+    assert_eq!(schedule.next(), Some(day_0 + delta * 6));
+    assert_eq!(schedule.next(), Some(day_0 + delta * 8));
+}

--- a/tests/test_schedules.rs
+++ b/tests/test_schedules.rs
@@ -123,3 +123,30 @@ pub fn test_throttling() {
     assert_eq!(schedule.next(), Some(day_0 + delta * 6));
     assert_eq!(schedule.next(), Some(day_0 + delta * 8));
 }
+
+// I want to create a schedule:
+// 1. firstly it will run at 10 seconds later,
+// 2. and then, it will run at every hour's 10th minute,
+// 3. meanwhile, it will run every 80 minutes,
+// 4. though, it won't run within 30 minutes after the last run.
+// 5. finally, it will stop running after 100 days later.
+#[test]
+pub fn test_complex_example() {
+    let start_time = now() + TimeDelta::seconds(10);
+    let schedule = Once::new(start_time)
+        .then(
+            Cron::utc_from_cron_expr("00 10 * * * *")
+                .expect("invalid cron")
+                .or(Period::new(
+                    TimeDelta::minutes(80),
+                    start_time + TimeDelta::minutes(80),
+                ))
+                .throttling(TimeDelta::minutes(30)),
+        )
+        .before(start_time + TimeDelta::days(100));
+    let mut _schedule = schedule.into_schedule();
+    // I don't want to run this test forever, so I will just check the first 10 runs.
+    for _ in 0..10 {
+        println!("{:?}", _schedule.next());
+    }
+}


### PR DESCRIPTION
1. Make the async wrapper running in a future, and stop by signal.
2. Add a [throttling](https://github.com/4t145/tsuki-scheduler/commit/392d35e7ba4f0c822d76c894c3702d983a766f98) wrapper.
3. Impl schedule for `AsMut<dyn Schedule>`.
4. Fix `time_mod`'s mod 0 bug.